### PR TITLE
remove pagination (quickfix)

### DIFF
--- a/is_homepage/apps/case_studies/models.py
+++ b/is_homepage/apps/case_studies/models.py
@@ -58,7 +58,7 @@ class CaseStudiesIndexPage(BasePage):
             case_studies_list = case_studies_list.filter(tags__name__in=tags)
 
         # Pagination.
-        paginator = Paginator(case_studies_list, 3)
+        paginator = Paginator(case_studies_list, 50)
         page = request.GET.get('page')
         try:
             case_studies_list = paginator.page(page)


### PR DESCRIPTION
Remove pagination in case studies by increasing the max number of case studies allowed per page.