### PR TITLE
feat: make pages searchable by text content

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ NHS Innovation Service Homepage is the entry point of all NHS services related t
 
 It is built with **Wagtail**, an open source content management framework.
 
+This README describes how to set up and run the project, but there are other docs (e.g. about search) in the [docs folder](./docs)
+
 
 ## Requirements
 

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -1,0 +1,48 @@
+# Notes about search functionality in Wagtail:
+
+We currently use Wagtail’s database search with Postgres DB, which uses Postgres's built in text-search functionality ([see code here][wg-pg]).  
+Although [the Postgres behaviour is configurable (e.g. using custom dictionaries)][pg-ts], we’re using the default set up.
+
+[wg-pg]:https://github.com/wagtail/wagtail/tree/main/wagtail/search/backends/database/postgres
+[pg-ts]:https://www.postgresql.org/docs/current/textsearch-intro.html#TEXTSEARCH-INTRO-CONFIGURATIONS
+
+## Default Behaviour
+The default behaviour of Postgres text search is:  
+It will:
+ - ignore common words (e.g. “the”, “and”, “in”)
+ - match based word-stem, .e.g. searching for “running”, will also find “runs” and “run”, searching for “tornado” will also find “tornadoes”
+ - rank multiple appearances of a word higher than a single appearance
+ - rank matches based on configured weights (1 of 4 levels, see below)
+
+It won’t:
+ - match synonyms e.g. “amazing”, “brilliant”, “awesome”
+ - match typos or incomplete words, e.g. searching for “brill” or “brill**ai**nt” instead of “brilliant”
+ - match quoted phrases exactly
+ - match unless all the search words are present, e.g. searching for "health board" will only match pages that contain both "health" and "board" (but health can be in the page title and board in the page content, for example)
+
+> NOTE: it seems the current search results are also ordered by most recent created date first (all other ranking factors being equal), perhaps that's explicitly defined somewhere
+
+## Ranking Weights
+
+Wagtail allows you to assign a “boost” value when adding something to the search index. This is then used when calculating the matching score, which is normally used to sort the search results ([as we do for the innovation service website][search-sort])
+
+[search-sort]:../is_homepage/apps/search/views.py#L96 
+
+By default Wagtail set boosts as follows:
+ - Matches in page title are ranked highest (boost of 2)
+ - Matches elsewhere are ranked equally (boost of 1)
+
+If adjusting boost values for the postgres backend, **it’s best to only use the values 10, 2, 1, or 0.**  This is because Postgres only supports 4 weights, so if you use a greater variety of boosts the end result can be a little hard to predict, as Wagtail will map the boosts to one of the 4 weights.
+
+If you need to troubleshoot what's going on with Wagtail's the boost-weight mapping you can run the Django shell (`python manage.py shell`) and run these commands:
+
+```python
+from wagtail.search.backends.database.postgres import weights
+weights.BOOSTS_WEIGHTS
+# outputs something like [(10, 'A'), (2, 'B'), (1, 'C'), (0, 'D')]
+```
+
+There’s a note about this in the [Wagtail docs](https://docs.wagtail.org/en/stable/topics/search/indexing.html#options)
+
+
+

--- a/is_homepage/apps/case_studies/models.py
+++ b/is_homepage/apps/case_studies/models.py
@@ -117,6 +117,7 @@ class CaseStudiesDetailPage(BasePage):
 
     # Search index configuration.
     search_fields = BasePage.search_fields + [
+        index.SearchField('content'),
         index.RelatedFields('case_studies_type', [index.SearchField('name')]),
         index.RelatedFields('tags', [index.SearchField('name')])
     ]

--- a/is_homepage/apps/case_studies/models.py
+++ b/is_homepage/apps/case_studies/models.py
@@ -117,7 +117,7 @@ class CaseStudiesDetailPage(BasePage):
 
     # Search index configuration.
     search_fields = BasePage.search_fields + [
-        index.SearchField('content'),
+        index.SearchField('content', boost=0),
         index.RelatedFields('case_studies_type', [index.SearchField('name')]),
         index.RelatedFields('tags', [index.SearchField('name')])
     ]

--- a/is_homepage/apps/innovation_guides/models.py
+++ b/is_homepage/apps/innovation_guides/models.py
@@ -82,7 +82,7 @@ class InnovationGuidesStagePage(PdfViewPageMixin, BasePage):
 
     # Search index configuration.
     search_fields = BasePage.search_fields + [
-        index.SearchField('content'),
+        index.SearchField('content', boost=0),
         index.RelatedFields('stage', [index.SearchField('name')]),
         index.RelatedFields('tags', [index.SearchField('name')])
     ]
@@ -125,7 +125,7 @@ class InnovationGuidesDetailPage(PdfViewPageMixin, BasePage):
 
     # Search index configuration.
     search_fields = BasePage.search_fields + [
-        index.SearchField('content'),
+        index.SearchField('content', boost=0),
         index.RelatedFields('stage', [index.SearchField('name')]),
         index.RelatedFields('tags', [index.SearchField('name')])
     ]

--- a/is_homepage/apps/innovation_guides/models.py
+++ b/is_homepage/apps/innovation_guides/models.py
@@ -82,6 +82,7 @@ class InnovationGuidesStagePage(PdfViewPageMixin, BasePage):
 
     # Search index configuration.
     search_fields = BasePage.search_fields + [
+        index.SearchField('content'),
         index.RelatedFields('stage', [index.SearchField('name')]),
         index.RelatedFields('tags', [index.SearchField('name')])
     ]
@@ -124,6 +125,7 @@ class InnovationGuidesDetailPage(PdfViewPageMixin, BasePage):
 
     # Search index configuration.
     search_fields = BasePage.search_fields + [
+        index.SearchField('content'),
         index.RelatedFields('stage', [index.SearchField('name')]),
         index.RelatedFields('tags', [index.SearchField('name')])
     ]

--- a/is_homepage/apps/news/models.py
+++ b/is_homepage/apps/news/models.py
@@ -131,9 +131,9 @@ class NewsDetailPage(BasePage):
 
     # Search index configuration.
     search_fields = BasePage.search_fields + [
-        index.SearchField('content'),
+        index.SearchField('content', boost=0),
         index.RelatedFields('news_type', [index.SearchField('name')]),
-        index.RelatedFields('tags', [index.SearchField('name')]),
+        index.RelatedFields('tags', [index.SearchField('name')])
     ]
 
     def get_context(self, request, *args, **kwargs):

--- a/is_homepage/apps/news/models.py
+++ b/is_homepage/apps/news/models.py
@@ -131,8 +131,9 @@ class NewsDetailPage(BasePage):
 
     # Search index configuration.
     search_fields = BasePage.search_fields + [
+        index.SearchField('content'),
         index.RelatedFields('news_type', [index.SearchField('name')]),
-        index.RelatedFields('tags', [index.SearchField('name')])
+        index.RelatedFields('tags', [index.SearchField('name')]),
     ]
 
     def get_context(self, request, *args, **kwargs):


### PR DESCRIPTION
## Make Content Easier to Find

The current search functionality does not index page content, making it harder to find pages.

These changes add the full page content to the search index, but configured so that matches by keyword tag are still ranked higher than page content (to reduce the noise from matches in page content). This is achieved by setting a low values for `boost` when adding the page content to the page index.

**NOTE:** If testing locally with existing content, you'll need to run `python manage.py update_index` for the changes to take effect (the release pipeline already does it in the post deployment steps)

## Other options/enhancements

### Elasticsearch
This PR still keeps the default (database) backend for search, for which [the documentation says:](https://docs.wagtail.org/en/stable/topics/search/backends.html#backend)  

_"this good enough to use in production on sites that don’t require any Elasticsearch specific features."_

If Elasticsearch specific features are required, then you might want to consider that as a backend options



