### PR TITLE
fix(docker): make Elastic Search active only if the ENV variable is set

### DIFF
--- a/is_homepage/settings/base.py
+++ b/is_homepage/settings/base.py
@@ -188,16 +188,24 @@ WAGTAIL_SITE_NAME = "Innovation Service Homepage"
 
 # Search
 # https://docs.wagtail.org/en/stable/topics/search/backends.html
-WAGTAILSEARCH_BACKENDS = {
-    "default": {
-        'BACKEND': 'wagtail.search.backends.elasticsearch8',
-        'URLS': [os.environ.get("ES_HOST")],
-        'INDEX': 'wagtail',
-        'TIMEOUT': 5,
-        'OPTIONS': {},
-        'INDEX_SETTINGS': {},
-    }
-}
+ES_HOST = os.environ.get('ES_HOST')
+if (ES_HOST):
+  WAGTAILSEARCH_BACKENDS = {
+      "default": {
+          'BACKEND': 'wagtail.search.backends.elasticsearch8',
+          'URLS': [ES_HOST],
+          'INDEX': 'wagtail',
+          'TIMEOUT': 5,
+          'OPTIONS': {},
+          'INDEX_SETTINGS': {},
+      }
+  }
+else:
+  WAGTAILSEARCH_BACKENDS = {
+      "default": {
+          'BACKEND': 'wagtail.search.backends.database',
+      }
+  }
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash


### PR DESCRIPTION
Description:
Make ES indexing optional.
If the ENV variable is set, use ES, otherwise fallback to PostGres search.

Closes: [#167172](https://nhsidev.visualstudio.com/InnovatorService/_workitems/edit/167172)